### PR TITLE
Fix issues of published versions of fuzzy-ml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fuzzy-ml"
-version = "0.0.4"
+version = "0.0.5"
 authors = [
   { name="John Wesley Hostetter", email="jhostetter16@gmail.com" },
 ]
@@ -23,8 +23,8 @@ Issues = "https://github.com/johnHostetter/fuzzy-ml/issues"
 
 [tool.hatch.build]
 include = [
-    "src/fuzzy-ml/**",
-    "src/crisp-ml/**",
+    "src/fuzzy_ml/**",
+    "src/crisp_ml/**",
     "README.md",
     "LICENSE",
 ]


### PR DESCRIPTION
The code in the `src` directory was not properly distributed in the published versions in PyPI. This pull request properly collects and distributes this code for use. Thus, all prior versions < 0.0.5 should _never_ be used.